### PR TITLE
Fix race accessing the connection proxy state in finalize()

### DIFF
--- a/src/main/java/com/maginatics/jdbclint/BlobProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/BlobProxy.java
@@ -56,10 +56,10 @@ final class BlobProxy implements InvocationHandler {
             final Object[] args) throws Throwable {
         String name = method.getName();
         if (name.equals("free")) {
-            if (config.isEnabled(Check.BLOB_DOUBLE_FREE) && freed.get()) {
+            boolean previouslyFreed = !freed.compareAndSet(false, true);
+            if (config.isEnabled(Check.BLOB_DOUBLE_FREE) && previouslyFreed) {
                 Utils.fail(config, exception, "Blob already freed");
             }
-            freed.set(true);
         }
 
         Object returnVal;

--- a/src/main/java/com/maginatics/jdbclint/BlobProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/BlobProxy.java
@@ -56,7 +56,7 @@ final class BlobProxy implements InvocationHandler {
             final Object[] args) throws Throwable {
         String name = method.getName();
         if (name.equals("free")) {
-            boolean previouslyFreed = !freed.compareAndSet(false, true);
+            boolean previouslyFreed = freed.getAndSet(true);
             if (config.isEnabled(Check.BLOB_DOUBLE_FREE) && previouslyFreed) {
                 Utils.fail(config, exception, "Blob already freed");
             }

--- a/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
@@ -25,6 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.maginatics.jdbclint.Configuration.Check;
 
@@ -46,7 +47,8 @@ public final class ConnectionProxy implements InvocationHandler {
         COMMITTED,
         CLOSED;
     }
-    private State state = State.OPENED;
+    private final AtomicReference<State> state =
+            new AtomicReference<State>(State.OPENED);
 
     /**
      * Create a ConnectionProxy.
@@ -74,24 +76,25 @@ public final class ConnectionProxy implements InvocationHandler {
         String name = method.getName();
         if (name.equals("close")) {
             if (config.isEnabled(Check.CONNECTION_DOUBLE_CLOSE) &&
-                    state == State.CLOSED) {
+                    state.get() == State.CLOSED) {
                 Utils.fail(config, exception, "Connection already closed");
             } else if (config.isEnabled(
                             Check.CONNECTION_MISSING_COMMIT_OR_ROLLBACK) &&
-                    !conn.getAutoCommit() && state == State.IN_TRANSACTION) {
-                state = State.CLOSED;
+                    !conn.getAutoCommit() &&
+                    state.get() == State.IN_TRANSACTION) {
+                state.set(State.CLOSED);
                 conn.close();
                 Utils.fail(config, exception,
                         "Connection did not commit or roll back");
             } else if (config.isEnabled(
                             Check.CONNECTION_MISSING_PREPARE_STATEMENT) &&
-                    state == State.OPENED) {
-                state = State.CLOSED;
+                    state.get() == State.OPENED) {
+                state.set(State.CLOSED);
                 conn.close();
                 Utils.fail(config, exception,
                         "Connection without prepareStatement");
             }
-            state = State.CLOSED;
+            state.set(State.CLOSED);
             if (config.isEnabled(Check.CONNECTION_MISSING_READ_ONLY) &&
                 isReadOnly() && !conn.isReadOnly()) {
                 conn.close();
@@ -100,7 +103,7 @@ public final class ConnectionProxy implements InvocationHandler {
                     "consider calling setReadOnly");
             }
         } else if (name.equals("commit") || name.equals("rollback")) {
-            state = State.COMMITTED;
+            state.set(State.COMMITTED);
         }
 
         Object returnVal;
@@ -110,11 +113,11 @@ public final class ConnectionProxy implements InvocationHandler {
             throw ite.getTargetException();
         }
         if (name.equals("createStatement")) {
-            state = State.IN_TRANSACTION;
+            state.set(State.IN_TRANSACTION);
             returnVal = StatementProxy.newInstance(this,
                     (Statement) returnVal, config);
         } else if (name.equals("prepareStatement")) {
-            state = State.IN_TRANSACTION;
+            state.set(State.IN_TRANSACTION);
             returnVal = StatementProxy.newInstance(this,
                     (PreparedStatement) returnVal, config);
         }
@@ -124,7 +127,7 @@ public final class ConnectionProxy implements InvocationHandler {
     @Override
     protected void finalize() throws SQLException {
         if (config.isEnabled(Check.CONNECTION_MISSING_CLOSE) &&
-                state != State.CLOSED) {
+                state.get() != State.CLOSED) {
             Utils.fail(config, exception, "Connection not closed");
         }
     }

--- a/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
@@ -81,15 +81,13 @@ public final class ConnectionProxy implements InvocationHandler {
             } else if (config.isEnabled(
                             Check.CONNECTION_MISSING_COMMIT_OR_ROLLBACK) &&
                     !conn.getAutoCommit() &&
-                    state.get() == State.IN_TRANSACTION) {
-                state.set(State.CLOSED);
+                    state.compareAndSet(State.IN_TRANSACTION, State.CLOSED)) {
                 conn.close();
                 Utils.fail(config, exception,
                         "Connection did not commit or roll back");
             } else if (config.isEnabled(
                             Check.CONNECTION_MISSING_PREPARE_STATEMENT) &&
-                    state.get() == State.OPENED) {
-                state.set(State.CLOSED);
+                    state.compareAndSet(State.OPENED, State.CLOSED)) {
                 conn.close();
                 Utils.fail(config, exception,
                         "Connection without prepareStatement");

--- a/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
@@ -100,7 +100,9 @@ public final class ConnectionProxy implements InvocationHandler {
                     "Connection did not execute updates, " +
                     "consider calling setReadOnly");
             }
-        } else if (name.equals("commit") || name.equals("rollback")) {
+            return null;
+        }
+        if (name.equals("commit") || name.equals("rollback")) {
             state.set(State.COMMITTED);
         }
 

--- a/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ConnectionProxy.java
@@ -94,7 +94,7 @@ public final class ConnectionProxy implements InvocationHandler {
             }
             state.set(State.CLOSED);
             if (config.isEnabled(Check.CONNECTION_MISSING_READ_ONLY) &&
-                isReadOnly() && !conn.isReadOnly()) {
+                    isReadOnly() && !conn.isReadOnly()) {
                 conn.close();
                 Utils.fail(config, exception,
                     "Connection did not execute updates, " +

--- a/src/main/java/com/maginatics/jdbclint/ResultSetProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ResultSetProxy.java
@@ -95,7 +95,7 @@ final class ResultSetProxy implements InvocationHandler {
             final Object[] args) throws Throwable {
         String name = method.getName();
         if (name.equals("close")) {
-            boolean previouslyClosed = !closed.compareAndSet(false, true);
+            boolean previouslyClosed = closed.getAndSet(true);
             if (config.isEnabled(Check.RESULT_SET_DOUBLE_CLOSE) &&
                     previouslyClosed) {
                 Utils.fail(config, exception, "ResultSet already closed");

--- a/src/main/java/com/maginatics/jdbclint/ResultSetProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/ResultSetProxy.java
@@ -104,7 +104,9 @@ final class ResultSetProxy implements InvocationHandler {
                 rs.close();
                 checkUnreadColumns();
             }
-        } else if (name.equals("next")) {
+            return null;
+        }
+        if (name.equals("next")) {
             return next();
         } else if (GETTERS.contains(name)) {
             String columnLabel;

--- a/src/main/java/com/maginatics/jdbclint/StatementProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/StatementProxy.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.maginatics.jdbclint.Configuration.Check;
 
@@ -46,7 +47,8 @@ final class StatementProxy implements InvocationHandler {
         EXECUTED,
         CLOSED;
     }
-    private State state = State.OPENED;
+    private final AtomicReference<State> state =
+            new AtomicReference<State>(State.OPENED);
 
     private final boolean checkDoubleClose;
     private final boolean checkMissingClose;
@@ -106,32 +108,31 @@ final class StatementProxy implements InvocationHandler {
             final Object[] args) throws Throwable {
         String name = method.getName();
         if (name.equals("addBatch")) {
-            state = State.IN_ADD_BATCH;
+            state.set(State.IN_ADD_BATCH);
         } else if (name.equals("executeBatch") ||
                 name.equals("executeLargeBatch")) {
-            state = State.EXECUTED;
+            state.set(State.EXECUTED);
         } else if (name.equals("execute") ||
                 name.equals("executeLargeUpdate") ||
                 name.equals("executeQuery") ||
                 name.equals("executeUpdate")) {
-            state = State.EXECUTED;
+            state.set(State.EXECUTED);
         } else if (name.equals("close")) {
-            if (checkDoubleClose && state == State.CLOSED) {
+            if (checkDoubleClose && state.get() == State.CLOSED) {
                 // Closing the same statement twice can cause issues with
                 // server-side statements.
                 Utils.fail(config, exception, className + " already closed");
-            } else if (checkMissingExecute && state == State.OPENED) {
-                state = State.CLOSED;
+            } else if (checkMissingExecute &&
+                    state.compareAndSet(State.OPENED, State.CLOSED)) {
                 stmt.close();
                 Utils.fail(config, exception, className + " without execute");
             } else if (checkMissingExecuteBatch &&
-                    state == State.IN_ADD_BATCH) {
-                state = State.CLOSED;
+                    state.compareAndSet(State.IN_ADD_BATCH, State.CLOSED)) {
                 stmt.close();
                 Utils.fail(config, exception,
                         className + " addBatch without executeBatch");
             }
-            state = State.CLOSED;
+            state.set(State.CLOSED);
         }
 
         // Be conservative and mark connection as non-readonly for all execute
@@ -158,7 +159,7 @@ final class StatementProxy implements InvocationHandler {
 
     @Override
     protected void finalize() throws SQLException {
-        if (checkMissingClose && state != State.CLOSED) {
+        if (checkMissingClose && state.get() != State.CLOSED) {
             Utils.fail(config, exception, className + " not closed");
         }
     }

--- a/src/main/java/com/maginatics/jdbclint/StatementProxy.java
+++ b/src/main/java/com/maginatics/jdbclint/StatementProxy.java
@@ -133,6 +133,7 @@ final class StatementProxy implements InvocationHandler {
                         className + " addBatch without executeBatch");
             }
             state.set(State.CLOSED);
+            return null;
         }
 
         // Be conservative and mark connection as non-readonly for all execute


### PR DESCRIPTION
Accesses to ConnectionProxy.state are unprotected and thus racy. This
leads to a situation where reading 'state' in the finalizer thread
gets an stale value long after it has been set to CLOSED in
ConnectionProxy.invoke in a different thread. This behavior has
been observed in unit tests for products that rely on JDBC lint.

Uses an atomic reference to ensure memory visibility. The
happens-after relationship is ensured by the fact that the
finalizer only runs after there are no reachable references
to the object. This means, this happens after the invoke
method has been executed.
